### PR TITLE
fix compilation over --all-features

### DIFF
--- a/src/noise/handshake.rs
+++ b/src/noise/handshake.rs
@@ -17,7 +17,7 @@ use std::convert::TryInto;
 use std::time::{Duration, SystemTime};
 
 #[cfg(feature = "mock-instant")]
-use mock_instant::Instant;
+use mock_instant::global::Instant;
 
 pub(crate) const LABEL_MAC1: &[u8; 8] = b"mac1----";
 pub(crate) const LABEL_COOKIE: &[u8; 8] = b"cookie--";

--- a/src/noise/mod.rs
+++ b/src/noise/mod.rs
@@ -738,7 +738,7 @@ mod tests {
 
         // Advance time 1 second and "send" 1 packet so that we send a handshake
         // after the timeout
-        mock_instant::MockClock::advance(Duration::from_secs(1));
+        mock_instant::global::MockClock::advance(Duration::from_secs(1));
         assert!(matches!(their_tun.update_timers(&mut []), TunnResult::Done));
         assert!(matches!(
             my_tun.update_timers(&mut my_dst),
@@ -749,7 +749,7 @@ mod tests {
         assert!(matches!(data, TunnResult::WriteToNetwork(_)));
 
         //Advance to timeout
-        mock_instant::MockClock::advance(REKEY_AFTER_TIME);
+        mock_instant::global::MockClock::advance(REKEY_AFTER_TIME);
         assert!(matches!(their_tun.update_timers(&mut []), TunnResult::Done));
         update_timer_results_in_handshake(&mut my_tun);
     }
@@ -763,7 +763,7 @@ mod tests {
         let packet = Tunn::parse_incoming_packet(&init).unwrap();
         assert!(matches!(packet, Packet::HandshakeInit(_)));
 
-        mock_instant::MockClock::advance(REKEY_TIMEOUT);
+        mock_instant::global::MockClock::advance(REKEY_TIMEOUT);
         update_timer_results_in_handshake(&mut my_tun)
     }
 

--- a/src/noise/rate_limiter.rs
+++ b/src/noise/rate_limiter.rs
@@ -3,7 +3,7 @@ use crate::noise::handshake::{LABEL_COOKIE, LABEL_MAC1};
 use crate::noise::{HandshakeInit, HandshakeResponse, Packet, Tunn, TunnResult, WireGuardError};
 
 #[cfg(feature = "mock-instant")]
-use mock_instant::Instant;
+use mock_instant::global::Instant;
 use portable_atomic::AtomicU64;
 use std::net::IpAddr;
 use std::sync::atomic::Ordering;

--- a/src/noise/timers.rs
+++ b/src/noise/timers.rs
@@ -9,7 +9,7 @@ use std::ops::{Index, IndexMut};
 use std::time::Duration;
 
 #[cfg(feature = "mock-instant")]
-use mock_instant::Instant;
+use mock_instant::global::Instant;
 
 #[cfg(not(feature = "mock-instant"))]
 use crate::sleepyinstant::Instant;

--- a/src/noise/tls.rs
+++ b/src/noise/tls.rs
@@ -9,8 +9,8 @@ pub fn verify_slices_are_equal(a: &[u8], b: &[u8]) -> Result<(), error::Unspecif
     Ok(())
 }
 
-#[cfg(feature = "aws-lc-rs")]
+#[cfg(all(feature = "aws-lc-rs", not(feature = "ring")))]
 pub use aws_lc_rs::*;
 
-#[cfg(feature = "aws-lc-rs")]
+#[cfg(all(feature = "aws-lc-rs", not(feature = "ring")))]
 pub use aws_lc_rs::constant_time::verify_slices_are_equal;


### PR DESCRIPTION
Resolves build failures when both ring and aws-lc-rs features are enabled simultaneously.

Fixed:
- Ambiguous imports: Added feature guards to prioritize ring over aws-lc-rs when both are enabled
- Invalid mock_instant::Instant imports: Changed to mock_instant::global::Instant

The build now succeeds with all feature combinations.